### PR TITLE
NLP Canvas - bug fixes, reserved words for names

### DIFF
--- a/src/nlp-visual-editor/components/rhs-panel.jsx
+++ b/src/nlp-visual-editor/components/rhs-panel.jsx
@@ -26,8 +26,8 @@ class RHSPanel extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.nodeId !== nextProps.nodeId) {
+  componentDidUpdate(prevProps) {
+    if (this.props.nodeId !== prevProps.nodeId) {
       //chaging panes, reset state
       this.setState({ editLabel: false, label: null });
     }

--- a/src/nlp-visual-editor/nlp-visual-editor.jsx
+++ b/src/nlp-visual-editor/nlp-visual-editor.jsx
@@ -272,17 +272,17 @@ class VisualEditor extends React.Component {
         ),
       },
       {
-        action: 'upload',
-        tooltip: 'Upload NLP Flow',
+        action: 'open',
+        tooltip: 'Open NLP Flow',
         jsx: (
           <>
             <label className="bx--btn bx--btn--md bx--btn--ghost">
-              Upload
+              Open
               <input
                 type="file"
-                id="btn-upload"
-                className="upload-button"
-                name="upload"
+                id="btn-open"
+                className="open-button"
+                name="open"
                 accept=".json"
                 onChange={this.onFlowSelected}
               />

--- a/src/nlp-visual-editor/nlp-visual-editor.scss
+++ b/src/nlp-visual-editor/nlp-visual-editor.scss
@@ -30,7 +30,7 @@
   }
 
   label {
-    .upload-button {
+    .open-button {
       width: 0.1px;
       height: 0.1px;
       opacity: 0;

--- a/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/dictionary-panel.jsx
@@ -15,12 +15,25 @@ class DictionaryPanel extends React.Component {
     this.state = {
       inputText: '',
       items: props.items,
-      caseSensitivity: props.caseSensitivity || 'match',
-      lemmaMatch: props.lemmaMatch || false,
-      externalResourceChecked: props.externalResourceChecked || false,
+      caseSensitivity: props.caseSensitivity,
+      lemmaMatch: props.lemmaMatch,
+      externalResourceChecked: props.externalResourceChecked,
       itemsSelected: [],
       errorMessage: undefined,
     };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.nodeId !== prevProps.nodeId) {
+      const { items, caseSensitivity, lemmaMatch, externalResourceChecked } =
+        this.props;
+      this.setState({
+        items,
+        caseSensitivity,
+        lemmaMatch,
+        externalResourceChecked,
+      });
+    }
   }
 
   getListItems = () => {
@@ -214,7 +227,10 @@ DictionaryPanel.propTypes = {
 };
 
 DictionaryPanel.defaultProps = {
+  caseSensitivity: 'match',
   items: [],
+  lemmaMatch: false,
+  externalResourceChecked: false,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/nlp-visual-editor/nodes/components/regex-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/regex-panel.jsx
@@ -8,7 +8,6 @@ import {
   NumberInput,
   RadioButton,
   RadioButtonGroup,
-  SkeletonText,
   TextArea,
 } from 'carbon-components-react';
 
@@ -22,6 +21,14 @@ class RegexPanel extends React.Component {
     this.state = {
       ...rest,
     };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.nodeId !== prevProps.nodeId) {
+      const { saveNlpNode, setShowRightPanel, children, label, ...rest } =
+        this.props;
+      this.setState({ ...rest });
+    }
   }
 
   fetchResults = () => {

--- a/src/nlp-visual-editor/nodes/components/sequence-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/sequence-panel.jsx
@@ -1,12 +1,7 @@
 import React, { Children, isValidElement, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import {
-  NumberInput,
-  RadioButton,
-  RadioButtonGroup,
-  TextArea,
-} from 'carbon-components-react';
+import { TextArea } from 'carbon-components-react';
 import './sequence-panel.scss';
 
 import { getImmediateUpstreamNodes } from '../../../utils';
@@ -16,14 +11,17 @@ class SequencePanel extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      pattern: '',
-      upstreamNodes: [],
+      pattern: this.props.pattern,
+      upstreamNodes: this.props.upstreamNodes,
     };
   }
 
   componentDidMount() {
-    const { pattern, upstreamNodes } = this.constructPattern();
-    this.setState({ pattern, upstreamNodes });
+    let { pattern, upstreamNodes } = this.props;
+    if (pattern === '') {
+      ({ pattern, upstreamNodes } = this.constructPattern());
+      this.setState({ pattern, upstreamNodes });
+    }
   }
 
   constructPattern = () => {
@@ -99,42 +97,6 @@ class SequencePanel extends React.Component {
     const { pattern } = this.state;
     return (
       <div className="sequence-panel">
-        <div className="sequence-token">
-          {/*<RadioButtonGroup
-            legendText="Separator"
-            name="rdSeparator"
-            defaultSelected="rd1"
-          >
-            <RadioButton labelText="Between" value="rd1" id="rd1" />
-            <RadioButton labelText="Exactly" value="rd2" id="rd2" />
-          </RadioButtonGroup>
-          <div className="token-controls">
-            <NumberInput
-              id="rangeNumFrom"
-              min={0}
-              max={99}
-              value={0}
-              size="sm"
-              label="tokens from"
-              hideLabel
-              invalidText="Number is not valid"
-              className="number-range"
-            />
-            <span>to</span>
-            <NumberInput
-              id="rangeNumTo"
-              min={0}
-              max={99}
-              value={0}
-              size="sm"
-              label="tokens to"
-              hideLabel
-              invalidText="Number is not valid"
-              className="number-range"
-            />
-            <span>tokens</span>
-          </div>*/}
-        </div>
         <TextArea
           id="inputPattern"
           labelText="Sequence pattern"
@@ -153,6 +115,11 @@ class SequencePanel extends React.Component {
 
 SequencePanel.propTypes = {
   pattern: PropTypes.string,
+};
+
+SequencePanel.defaultProps = {
+  pattern: '',
+  upstreamNodes: [],
 };
 
 const mapStateToProps = (state) => ({

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,8 +2,8 @@ function isNodeLabelValid(label, existingNodes) {
   if (label === undefined || label.trim().length === 0) {
     return { isValid: false, message: 'Name cannot be empty.' };
   }
-  //node name cannot be called dictionary, it is a reserved word
-  if (label.toLowerCase() === 'dictionary') {
+  //node name cannot be called dictionary | regex, reserved word
+  if (['dictionary', 'regex'].includes(label.toLowerCase())) {
     return {
       isValid: false,
       message: `${label} is a reserved word.`,


### PR DESCRIPTION
This PR addresses:
- `regex` is a reserved word in AQL and cannot be used as node name.
- rename button to `Open` from `Load`
- when selecting same type of nodes within the flow, the values do not get updated on the RHS panel.