### PR TITLE
save node name onBlur, validate json files when opening flow

### DIFF
--- a/sample-flows/test-sequence-node.json
+++ b/sample-flows/test-sequence-node.json
@@ -263,7 +263,7 @@
       "type": "sequence",
       "description": "Connect your extractors for execution",
       "isValid": true,
-      "pattern": "(<Metric.Metric>)<Token>{0,0}(<Preposition.Preposition>)<Token>{1,2}(<Division.Division>)",
+      "pattern": "(<Metric.Metric>)<Token>{0,0}(<Preposition.Preposition>)<Token>{0,2}(<Division.Division>)",
       "upstreamNodes": [
         { "label": "Metric", "nodeId": "d88d7167-3b2c-427a-9b50-27049feb904d" },
         {
@@ -277,7 +277,7 @@
       ],
       "tokens": [
         { "min": "0", "max": "0" },
-        { "min": "1", "max": "2" }
+        { "min": "0", "max": "2" }
       ]
     },
     {

--- a/src/nlp-visual-editor/components/rhs-panel.jsx
+++ b/src/nlp-visual-editor/components/rhs-panel.jsx
@@ -104,10 +104,13 @@ class RHSPanel extends React.Component {
         onChange={(e) => {
           this.setState({ label: e.target.value });
         }}
+        onBlur={this.onSaveLabel}
         onKeyDown={(e) => {
           const keyPressed = e.key || e.keyCode;
           if (keyPressed === 'Enter' || keyPressed === 13) {
             this.onSaveLabel();
+          } else if (keyPressed === 'Escape' || keyPressed === 27) {
+            this.setState({ editLabel: false, label: null });
           }
         }}
         value={label}

--- a/src/nlp-visual-editor/nlp-visual-editor.jsx
+++ b/src/nlp-visual-editor/nlp-visual-editor.jsx
@@ -243,10 +243,15 @@ class VisualEditor extends React.Component {
     formData.append('workingId', workingId);
     try {
       const { data } = await axios.post('/api/uploadflow', formData);
+      const { flow, nodes } = data;
+      if (flow === undefined || nodes === undefined) {
+        throw 'File does not conform to the Elyra NLP Tooling schema.';
+      }
       this.setPipelineFlow(data);
     } catch (ex) {
-      //TODO handle error
       console.log(ex);
+      const errorMessage = typeof ex === 'object' ? ex.toString() : ex;
+      this.setState({ errorMessage });
     }
   };
 
@@ -422,12 +427,12 @@ class VisualEditor extends React.Component {
       return null;
     }
     const node = nodes.find((n) => n.nodeId === selectedNodeId);
-    const { label } = node;
+    const heading = node ? node.label : 'Error';
     return (
       <Modal
         alert={true}
         open={true}
-        modalHeading={label}
+        modalHeading={heading}
         primaryButtonText="OK"
         size="sm"
         onClick={this.onErrorModalClosed}


### PR DESCRIPTION
Fixes the following:
- saves the name of the node when the user clicks away (onBlur) after modifying the name. 
- validates and gives error if when opening a flow, the file does not conform to the Elyra NLP tooling schema.
- updates the sequence sample flow file