### PR TITLE
Fix node deletion bug

### DIFF
--- a/src/nlp-visual-editor/components/rhs-panel.jsx
+++ b/src/nlp-visual-editor/components/rhs-panel.jsx
@@ -11,7 +11,7 @@ import {
   DictionaryPanel,
   SequencePanel,
   UnionPanel,
-  LiteralPanel
+  LiteralPanel,
 } from '../nodes/components';
 
 import { isNodeLabelValid } from '../../utils';
@@ -42,9 +42,9 @@ class RHSPanel extends React.Component {
     switch (type) {
       case 'input':
         return <InputPanel {...node} />;
-	  case 'literal':
-		return <LiteralPanel {...node} />;	
-	  case 'regex':
+      case 'literal':
+        return <LiteralPanel {...node} />;
+      case 'regex':
         return <RegexPanel {...node} />;
       case 'dictionary':
         return (
@@ -122,6 +122,9 @@ class RHSPanel extends React.Component {
 
   render() {
     const node = this.getNodeProps();
+    if (!node) {
+      return <p>Select a node to edit its properties.</p>;
+    }
     const { description, type } = node;
     const panelContents = this.getPanelContent(type);
     const titleComponent = this.getTitleComponent();


### PR DESCRIPTION
Fixes #32. Deleting a node while the properties flyout was open was causing the editor to crash because the node being edited was undefined after deletion. This checks for existence of the node before trying to access any values. 

**Note**: I included a message for completeness but it shouldn't actually show up with the current UX, so I didn't add any style for the text. 

Also - seems like it added some indentation from the lint automatically. Shouldn't change the behavior of the editor at all