### PR TITLE
Fix sequence bug

### DIFF
--- a/src/nlp-visual-editor/nodes/components/sequence-panel.jsx
+++ b/src/nlp-visual-editor/nodes/components/sequence-panel.jsx
@@ -27,8 +27,15 @@ class SequencePanel extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.nodeId !== prevProps.nodeId) {
-      const { pattern, upstreamNodes } = this.props;
-      this.setState({ pattern, upstreamNodes });
+      if (this.props.pattern === '') {
+        const { pattern, upstreamNodes } = this.constructPattern();
+        this.setState({ pattern, upstreamNodes });
+      } else {
+        this.setState({
+          pattern: this.props.pattern,
+          upstreamNodes: this.props.upstreamNodes,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #30 - when switching between sequence nodes the `componentDidUpdate` was being called instead of `componentDidMount`, which had different ways of handling the population of the sequence field. This adjusts them to handle it in the same way. 